### PR TITLE
Return BigInt for more Big Integers

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -192,7 +192,7 @@ module.exports = class Decoder {
       }
       case SMALL_BIG_EXT: {
         const digits = this.read8();
-        return digits >= 8 ? this.decodeBigBigInt(digits) : this.decodeBigNumber(digits);
+        return digits >= 7 ? this.decodeBigBigInt(digits) : this.decodeBigNumber(digits);
       }
       case LARGE_BIG_EXT: {
         const digits = this.read32();


### PR DESCRIPTION
Each digit is 8 bits, largest Number integer is 52 bits, meaning at 6.5 digits or higher this should return a BigInt. Given digits is an int, however, seems safer to set at >=7. Probably not perfect, but this solves the specific issue I raised to you earlier.