### PR TITLE
docs: Fixed undeclared constant in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ console.log(unpack(buf)); // { a : 1n }
 ```
 
 ```js
-const { pack } = require('earl');
+const { pack, unpack } = require('earl');
 
 class User {
   constructor(data) {


### PR DESCRIPTION
In the first example, `pack` and `unpack` are deconstructed and used, in the second, both were used but `unpack` was not deconstructed. 